### PR TITLE
Check if another program is listening on port 53

### DIFF
--- a/unbound-install.sh
+++ b/unbound-install.sh
@@ -5,6 +5,13 @@ if [[ "$UID" -ne 0 ]]; then
 	exit 1
 fi
 
+if [[ $(netstat -ulpn | grep :53) != "" ]]; then
+		echo "Looks like another software is listnening on UDP port 53:"
+		netstat -ulnp | grep :53
+		echo "Please uninstall it before installing unbound."
+	exit 1
+fi
+
 if [[ -e /etc/debian_version ]]; then
 	# Detects all variants of Debian, including Ubuntu
 	OS="debian"

--- a/unbound-install.sh
+++ b/unbound-install.sh
@@ -8,7 +8,7 @@ fi
 if [[ $(netstat -ulpn | grep :53) != "" ]]; then
 		echo "Looks like another software is listnening on UDP port 53:"
 		netstat -ulnp | grep :53
-		echo "Please uninstall it before installing unbound."
+		echo "Please disable or uninstall it before installing unbound."
 	exit 1
 fi
 

--- a/unbound-install.sh
+++ b/unbound-install.sh
@@ -5,14 +5,14 @@ if [[ "$UID" -ne 0 ]]; then
 	exit 1
 fi
 
-netstat=$(netstat -ulpn)
-if [[ $netstat | grep :53) != "" ]]; then
-		echo "It looks like another software is listnening on UDP port 53:"
-		echo ""
-		echo $netstat | grep :53
-		echo ""
-		echo "Please disable or uninstall it before installing unbound."
-	exit 1
+lsof -i udp@0.0.0.0:53 > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+    echo "It looks like another software is listnening on UDP port 53:"
+    echo ""
+    lsof -i udp@0.0.0.0:53
+    echo ""
+    echo "Please disable or uninstall it before installing unbound."
+    exit 1
 fi
 
 if [[ -e /etc/debian_version ]]; then

--- a/unbound-install.sh
+++ b/unbound-install.sh
@@ -5,9 +5,12 @@ if [[ "$UID" -ne 0 ]]; then
 	exit 1
 fi
 
-if [[ $(netstat -ulpn | grep :53) != "" ]]; then
-		echo "Looks like another software is listnening on UDP port 53:"
-		netstat -ulnp | grep :53
+netstat=$(netstat -ulpn)
+if [[ $netstat | grep :53) != "" ]]; then
+		echo "It looks like another software is listnening on UDP port 53:"
+		echo ""
+		echo $netstat | grep :53
+		echo ""
 		echo "Please disable or uninstall it before installing unbound."
 	exit 1
 fi


### PR DESCRIPTION
More specifically, listening on the port 53 with UDP, and for whatever IP address.

Without the check, if there is already another program listening (bind, dsnmasq...), unbound won't start.