### PR TITLE
Remove duplicate lines and fix for DNS rebinding not applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The resolver is "local" because Unbound will only listen on localhost and accept
 
 The script is designed to work on the following OS:
 
-* Debian 7+
+* Debian 8+
 * Ubuntu 14+
 * CentOS 7
 * Fedora 25+

--- a/unbound-install.sh
+++ b/unbound-install.sh
@@ -46,9 +46,6 @@ hide-version: yes
 use-caps-for-id: yes
 prefetch: yes' >> /etc/unbound/unbound.conf
 
-  # Restart Unbound
-  service unbound restart
-
   # Needed for the chattr command
   apt-get install -y e2fsprogs
 fi
@@ -61,11 +58,6 @@ if [[ "$OS" = "centos" ]]; then
   sed -i 's|# hide-identity: no|hide-identity: yes|' /etc/unbound/unbound.conf
   sed -i 's|# hide-version: no|hide-version: yes|' /etc/unbound/unbound.conf
   sed -i 's|use-caps-for-id: no|use-caps-for-id: yes|' /etc/unbound/unbound.conf
-
-  # Enable service at boot
-  systemctl enable unbound
-  # Start the service
-  systemctl start unbound
 fi
 
 if [[ "$OS" = "fedora" ]]; then
@@ -76,11 +68,6 @@ if [[ "$OS" = "fedora" ]]; then
   sed -i 's|# hide-identity: no|hide-identity: yes|' /etc/unbound/unbound.conf
   sed -i 's|# hide-version: no|hide-version: yes|' /etc/unbound/unbound.conf
   sed -i 's|# use-caps-for-id: no|use-caps-for-id: yes|' /etc/unbound/unbound.conf
-
-  # Enable service at boot
-  systemctl enable unbound
-  # Start the service
-  systemctl start unbound
 fi
 
 if [[ "$OS" = "arch" ]]; then
@@ -110,16 +97,17 @@ hide-identity: yes
 hide-version: yes
 qname-minimisation: yes
 prefetch: yes' > /etc/unbound/unbound.conf
-
-  # Enable service at boot
-  systemctl enable unbound
-  # Start the service
-  systemctl start unbound
 fi
 
 # DNS Rebinding fix
 PRIVATE_ADDRESSES="10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 169.254.0.0/16 fd00::/8 fe80::/10 127.0.0.0/8 ::ffff:0:0/96"
 echo "private-address: $PRIVATE_ADDRESSES" >> /etc/unbound/unbound.conf
+
+# Enable service at boot
+systemctl enable unbound
+
+# Restart the service
+systemctl restart unbound
 
 # Allow the modification of the file
 chattr -i /etc/resolv.conf


### PR DESCRIPTION
DNS rebinding fix is added to the configuration after restarting Unbound, thus it is not applied until a new restart or machine reboot.